### PR TITLE
ci: restrict update-dist GitHub App token scope

### DIFF
--- a/.github/workflows/update-dist.yml
+++ b/.github/workflows/update-dist.yml
@@ -26,6 +26,8 @@ jobs:
           app-id: ${{ secrets.GHACTIONS_REPO_WRITE_APP_ID }}
           private-key: ${{ secrets.GHACTIONS_REPO_WRITE_APP_PRIVATE_KEY }}
           owner: docker
+          repositories: setup-compose-action
+          permission-contents: write
       -
         name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
similar to https://github.com/docker/bake-action/pull/443