### PR TITLE
chore: allow actions-toolkit to bypass yarn age gate

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -14,6 +14,9 @@ logFilters:
   - code: YN0086
     level: discard
 
+npmPreapprovedPackages:
+  - "@docker/actions-toolkit"
+
 compressionLevel: mixed
 enableGlobalCache: false
 enableHardenedMode: true


### PR DESCRIPTION
similar to https://github.com/docker/setup-qemu-action/pull/314